### PR TITLE
Add image sensor to HQ cam model

### DIFF
--- a/raspi_cam_hq_models/models/HQ_Camera_model.scad
+++ b/raspi_cam_hq_models/models/HQ_Camera_model.scad
@@ -480,6 +480,7 @@ module raspi_hq_camera_model (install_ccs_adapter = true,
                 mirror([0,0,0])
                     sensor_housing(install_ccs_adapter = install_ccs_adapter,
                                    install_tripod_mount = install_tripod_mount);
+                color("Blue") cube([10,10,1],center=true);
             }
 
             // keepout spacers around screws


### PR DESCRIPTION
I've had an usecase where I needed to take the exact location of the sensor into account (not just the C-mount), so I added that. Thanks for the nice model!